### PR TITLE
Fix `E/AudioRecord: start() status -1` by starting the recorder immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is tweaked version of original by rom1v.
 This version has some features:
 - Support changing sampling rate and buffer size
 - Show sampling rate in notification
+- Automatically restart on socket disconnect
+- Log when socket is ready and when it's restarting.
+- Corrected a bug where the AudioRecorder
 
 ## Changing sampling rate
 To change sampling rate, add to `am` command with `--ei SAMPLE_RATE FREQ` option.

--- a/app/src/main/java/com/rom1v/sndcpy/RecordService.java
+++ b/app/src/main/java/com/rom1v/sndcpy/RecordService.java
@@ -153,6 +153,7 @@ public class RecordService extends Service {
 
     private static LocalSocket connect() throws IOException {
         LocalServerSocket localServerSocket = new LocalServerSocket(SOCKET_NAME);
+        Log.i(TAG, "Socket Ready!");
         try {
             return localServerSocket.accept();
         } finally {
@@ -186,6 +187,7 @@ public class RecordService extends Service {
 
     private void startRecording() {
         final AudioRecord recorder = createAudioRecord(mediaProjection);
+        recorder.startRecording();
 
         recorderThread = new Thread(new Runnable() {
             @Override
@@ -193,7 +195,7 @@ public class RecordService extends Service {
                 try (LocalSocket socket = connect()) {
                     handler.sendEmptyMessage(MSG_CONNECTION_ESTABLISHED);
 
-                    recorder.startRecording();
+
                     int BUFFER_MS = 10; // do not buffer more than BUFFER_MS milliseconds
                     byte[] buf = new byte[SAMPLE_RATE * CHANNELS * BUFFER_MS / 1000];
                     while (true) {
@@ -203,8 +205,10 @@ public class RecordService extends Service {
                 } catch (IOException e) {
                     // ignore
                 } finally {
-                    recorder.stop();
-                    stopSelf();
+                    Log.w(TAG, "Connection Dropped, Not Ready!");
+                    run();
+                    //recorder.stop();
+                    //stopSelf();
                 }
             }
         });

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
By moving `recorder.startRecording();` outside of the Thread this prevents the recorder from going stale and crashing the app randomly. Why exactly the recorder will just crash if you wait to long to connect is unknown to me but when you immediately start it the app is much more reliable (to the point it has not crash yet under my tests)

I replaced the "exit the app" on disconnect with a restart of the socket to allow for the service to handle disconnects and not require the entire restart procedure just to reopen the socket

And added logging so its possible to monitor if the socket is ready to prevent connecting to early for applications that are sensitive to expecting the connection to be ready immediately (cough ffmpeg)

My revision is mainly to help with my automated recording software that I use to record XM radio but i think it could help the project in general